### PR TITLE
Remove timezone from schedule

### DIFF
--- a/pkg/v1/model/schedule.go
+++ b/pkg/v1/model/schedule.go
@@ -10,7 +10,6 @@ type Schedule struct {
 	CommonEnable
 	CommonThingClass
 	CommonThingType
-	TimeZone          string         `json:"timezone"`
 	IsActive          *bool          `json:"is_active"`
 	ActiveWeekly      *bool          `json:"active_weekly"`
 	ActiveException   *bool          `json:"active_exception"`


### PR DESCRIPTION
### Summary:
- Removed `timezone` from `schedule`