### PR TITLE
Remove point_histories foreign key

### DIFF
--- a/model/point.go
+++ b/model/point.go
@@ -74,7 +74,6 @@ type Point struct {
 	MetaTags          []*PointMetaTag `json:"meta_tags,omitempty" gorm:"constraint:OnDelete:CASCADE"`
 	Connection        string          `json:"connection" gorm:"default:Connected"`
 	ConnectionMessage *string         `json:"connection_message" gorm:""`
-	PointHistories    []*PointHistory `json:"point_histories,omitempty" gorm:"constraint:OnDelete:CASCADE"`
 	CommonSourceUUID
 	LastHistoryValue     *float64       `json:"last_history_value,omitempty"`
 	LastHistoryTimestamp *time.Time     `json:"last_history_timestamp,omitempty"`

--- a/model/pointhistory.go
+++ b/model/pointhistory.go
@@ -6,7 +6,7 @@ import (
 
 type PointHistory struct {
 	ID        int       `json:"id" gorm:"autoIncrement;primaryKey;index"`
-	PointUUID string    `json:"point_uuid,omitempty" gorm:"type:varchar(255) references points;not null;default:null"`
+	PointUUID string    `json:"point_uuid,omitempty" gorm:"type:varchar(255);not null;default:null"`
 	Value     *float64  `json:"present_value"`
 	Timestamp time.Time `json:"timestamp,omitempty"`
 }


### PR DESCRIPTION
### Summary:

- Removed `point_histories` foreign key. _(Reason: Cascade delete is too slow)_